### PR TITLE
Fix packaging dependencies for mac build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,15 +19,15 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.4.1",
         "uuid": "^11.1.0",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "electron-is-dev": "^3.0.1",
+        "electron-log": "^5.4.0"
       },
       "devDependencies": {
         "concurrently": "^9.1.2",
         "cross-env": "^7.0.3",
         "electron": "^36.2.1",
         "electron-builder": "^26.0.12",
-        "electron-is-dev": "^3.0.1",
-        "electron-log": "^5.4.0",
         "react-scripts": "^5.0.1",
         "wait-on": "^8.0.3"
       }
@@ -10095,7 +10095,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-3.0.1.tgz",
       "integrity": "sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10108,7 +10108,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.0.tgz",
       "integrity": "sha512-AXI5OVppskrWxEAmCxuv8ovX+s2Br39CpCAgkGMNHQtjYT3IiVbSQTncEjFVGPgoH35ZygRm/mvUMBDWwhRxgg==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.4.1",
     "uuid": "^11.1.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "electron-is-dev": "^3.0.1",
+    "electron-log": "^5.4.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -50,8 +52,6 @@
     "cross-env": "^7.0.3",
     "electron": "^36.2.1",
     "electron-builder": "^26.0.12",
-    "electron-is-dev": "^3.0.1",
-    "electron-log": "^5.4.0",
     "react-scripts": "^5.0.1",
     "wait-on": "^8.0.3"
   },


### PR DESCRIPTION
## Summary
- ensure `electron-is-dev` and `electron-log` are included in production builds by moving them from devDependencies
- update lockfile accordingly

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841451dad348330af55413b3f699d2c